### PR TITLE
Add vscode-extension.vsix to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ waf2*
 waf3*
 x64
 cquery_log.txt
+vscode-extension.vsix


### PR DESCRIPTION
This file is generated by vscode-client/build.py but is not checked in.