### PR TITLE
Fix build on Ubuntu 16.04

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -10,6 +10,7 @@
 #include <loguru.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <climits>
 #include <iostream>
@@ -126,6 +127,8 @@ ClangStorageClass GetStorageClass(CX_StorageClass storage) {
       return ClangStorageClass::SC_Auto;
     case CX_SC_Register:
       return ClangStorageClass::SC_Register;
+    default:
+      assert(0);
   }
 }
 


### PR DESCRIPTION
On Ubuntu 16.04 I get the following compile error in release mode:

../../src/indexer.cc: In function ‘ClangStorageClass {anonymous}::GetStorageClass(CX_StorageClass)’:
../../src/indexer.cc:130:1: error: control reaches end of non-void function [-Werror=return-type]

cc1plus: all warnings being treated as errors

(I'm not sure if your standard is 'assert' in these cases, but there seemed be be a few other usages in the codebase)