### PR TITLE
Fix completion of headers.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -67,7 +67,8 @@ struct Config {
   // An example value is { ".h", ".hpp" }
   //
   // This is significantly faster than using a regex.
-  std::vector<std::string> includeCompletionWhitelistLiteralEnding;
+  std::vector<std::string> includeCompletionWhitelistLiteralEnding = {
+      ".h", ".hpp", ".hh"};
   // Regex patterns to match include completion candidates against. They
   // receive the absolute file path.
   //

--- a/src/include_complete.cc
+++ b/src/include_complete.cc
@@ -78,30 +78,18 @@ bool TrimPath(Project* project,
 
 lsCompletionItem BuildCompletionItem(Config* config,
                                      const std::string& path,
-                                     bool use_angle_brackets,
+                                     bool /*use_angle_brackets*/,
                                      bool is_stl) {
   lsCompletionItem item;
-  if (use_angle_brackets)
-    item.label = "#include <" + ElideLongPath(config, path) + ">";
-  else
-    item.label = "#include \"" + ElideLongPath(config, path) + "\"";
-
+  item.label = ElideLongPath(config, path);
   item.detail = path;
-
-  // Replace the entire existing content.
-  // NOTE: When submitting completion items, textEdit->range must be updated.
   item.textEdit = lsTextEdit();
-  if (use_angle_brackets)
-    item.textEdit->newText = "#include <" + path + ">";
-  else
-    item.textEdit->newText = "#include \"" + path + "\"";
-
+  item.textEdit->newText = path;
   item.insertTextFormat = lsInsertTextFormat::PlainText;
   if (is_stl)
     item.kind = lsCompletionItemKind::Module;
   else
     item.kind = lsCompletionItemKind::File;
-
   return item;
 }
 
@@ -127,8 +115,8 @@ void IncludeComplete::Rescan() {
     Timer timer;
 
     InsertStlIncludes();
-    InsertIncludesFromDirectory(config_->projectRoot,
-                                false /*use_angle_brackets*/);
+    // InsertIncludesFromDirectory(config_->projectRoot,
+    //                             false /*use_angle_brackets*/);
     for (const std::string& dir : project_->quote_include_directories)
       InsertIncludesFromDirectory(dir, false /*use_angle_brackets*/);
     for (const std::string& dir : project_->angle_include_directories)

--- a/src/lex_utils.cc
+++ b/src/lex_utils.cc
@@ -44,11 +44,32 @@ lsPosition CharPos(const std::string& search,
   return result;
 }
 
-bool ShouldRunIncludeCompletion(const std::string& line) {
+std::tuple<bool, std::string, std::string> ShouldRunIncludeCompletion(
+    const std::string& line) {
   size_t start = 0;
   while (start < line.size() && isspace(line[start]))
     ++start;
-  return start < line.size() && line[start] == '#';
+  if (start >= line.size() || line[start] != '#')
+    return std::make_tuple(false, "", "");
+  ++start;
+  if (line.compare(start, 7, "include") == 0) {
+    start += 7;
+    while (start < line.size() && isspace(line[start]))
+      ++start;
+  }
+  std::string surrounding, prefix;
+  if (start >= line.size())
+    return std::make_tuple(false, "", "");
+  else if (line[start] == '"')
+    surrounding = "\"\"";
+  else if (line[start] == '<')
+    surrounding = "<>";
+  else
+    return std::make_tuple(false, "", "");
+  ++start;
+  if (start < line.size())
+    prefix = line.substr(start);
+  return std::make_tuple(true, surrounding, prefix);
 }
 
 // TODO: eliminate |line_number| param.

--- a/src/lex_utils.h
+++ b/src/lex_utils.h
@@ -3,6 +3,7 @@
 #include "language_server_api.h"
 
 #include <string>
+#include <tuple>
 
 // Utility method to map |position| to an offset inside of |content|.
 int GetOffsetForPosition(lsPosition position, const std::string& content);
@@ -11,7 +12,8 @@ lsPosition CharPos(const std::string& search,
                    char character,
                    int character_offset = 0);
 
-bool ShouldRunIncludeCompletion(const std::string& line);
+std::tuple<bool, std::string, std::string> ShouldRunIncludeCompletion(
+    const std::string& line);
 
 // TODO: eliminate |line_number| param.
 optional<lsRange> ExtractQuotedRange(int line_number, const std::string& line);

--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -284,7 +284,10 @@ struct TextDocumentCompletionHandler : MessageHandler {
           &existing_completion);
     }
 
-    if (ShouldRunIncludeCompletion(buffer_line)) {
+    bool yes;
+    std::string surrounding, prefix;
+    std::tie(yes, surrounding, prefix) = ShouldRunIncludeCompletion(buffer_line);
+    if (yes) {
       Out_TextDocumentComplete out;
       out.id = request->id;
 
@@ -297,18 +300,17 @@ struct TextDocumentCompletionHandler : MessageHandler {
                                 include_complete->completion_items.end());
         if (lock)
           lock.unlock();
-
-        // Update textEdit params.
         for (lsCompletionItem& item : out.result.items) {
           item.textEdit->range.start.line = request->params.position.line;
           item.textEdit->range.start.character = 0;
           item.textEdit->range.end.line = request->params.position.line;
           item.textEdit->range.end.character = (int)buffer_line.size();
+          item.textEdit->newText = std::string("#include ") + surrounding[0] +
+                                   item.textEdit->newText + surrounding[1];
         }
       }
 
-      TrimInPlace(buffer_line);
-      FilterAndSortCompletionResponse(&out, buffer_line,
+      FilterAndSortCompletionResponse(&out, prefix,
                                       config->completion.filterAndSort);
       QueueManager::WriteStdout(IpcId::TextDocumentCompletion, out);
     } else {


### PR DESCRIPTION
1. Set a default value of `includeCompletionWhitelistLiteralEnding`. Otherwise no header is found.
2. Only complete line that starts with `#include "` or `#include <`. So we can determine the last complete character.
3. Filter and sort the candidates without prefix `#include`.