### PR TITLE
Proposal: improved completion results

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -135,6 +135,25 @@ struct Config {
     // false for the option. This option is the most useful for LSP clients
     // that implement their own filtering and sorting logic.
     bool filterAndSort = true;
+
+    // Some completion UI, such as Emacs' completion-at-point and company-lsp,
+    // display completion item label and detail side by side.
+    // This does not look right, when you see things like:
+    //     "foo" "int foo()"
+    //     "bar" "void bar(int i = 0)"
+    // When this option is enabled, the completion item label is very detailed,
+    // it shows the full signature of the candidate.
+    // The detail just contains the completion item parent context.
+    // Also, in this mode, functions with default arguments,
+    // generates one more item per default argument
+    // so that the right function call can be selected.
+    // That is, you get something like:
+    //     "int foo()" "Foo"
+    //     "void bar()" "Foo"
+    //     "void bar(int i = 0)" "Foo"
+    // Be wary, this is quickly quite verbose,
+    // items can end up truncated by the UIs.
+    bool detailedLabel = false;
   };
   Completion completion;
 
@@ -162,7 +181,7 @@ struct Config {
   std::vector<std::string> dumpAST;
 };
 MAKE_REFLECT_STRUCT(Config::ClientCapability, snippetSupport);
-MAKE_REFLECT_STRUCT(Config::Completion, filterAndSort);
+MAKE_REFLECT_STRUCT(Config::Completion, filterAndSort, detailedLabel);
 MAKE_REFLECT_STRUCT(Config::Index, comments, attributeMakeCallsToCtor);
 MAKE_REFLECT_STRUCT(Config,
                     compilationDatabaseDirectory,

--- a/src/language_server_api.h
+++ b/src/language_server_api.h
@@ -365,7 +365,7 @@ struct lsCompletionItem {
 
   // A string that should be used when filtering a set of
   // completion items. When `falsy` the label is used.
-  // std::string filterText;
+  std::string filterText;
 
   // A string that should be inserted a document when selecting
   // this completion. When `falsy` the label is used.
@@ -407,6 +407,7 @@ MAKE_REFLECT_STRUCT(lsCompletionItem,
                     documentation,
                     sortText,
                     insertText,
+                    filterText,
                     insertTextFormat,
                     textEdit);
 

--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -68,17 +68,16 @@ struct Out_TextDocumentComplete
 };
 MAKE_REFLECT_STRUCT(Out_TextDocumentComplete, jsonrpc, id, result);
 
-bool CompareLsCompletionItem(const lsCompletionItem& item1,
-                             const lsCompletionItem& item2) {
-  if (item1.found_ != item2.found_)
-    return item1.found_ > item2.found_;
-  if (item1.skip_ != item2.skip_)
-    return item1.skip_ < item2.skip_;
-  if (item1.priority_ != item2.priority_)
-    return item1.priority_ < item2.priority_;
-  if (item1.label.length() != item2.label.length())
-    return item1.label.length() < item2.label.length();
-  return item1.label < item2.label;
+bool CompareLsCompletionItem(const lsCompletionItem& lhs,
+                             const lsCompletionItem& rhs) {
+  const auto lhsFilterTextLength = lhs.filterText.length();
+  const auto lhsLabelLength = lhs.label.length();
+  const auto rhsFilterTextLength = rhs.filterText.length();
+  const auto rhsLabelLength = rhs.label.length();
+  return std::tie(lhs.found_, lhs.skip_, lhs.priority_, lhsFilterTextLength,
+                  lhs.filterText, lhsLabelLength, lhs.label) <
+         std::tie(rhs.found_, rhs.skip_, rhs.priority_, rhsFilterTextLength,
+                  rhs.filterText, rhsLabelLength, lhs.label);
 }
 
 template <typename T>
@@ -129,11 +128,18 @@ void FilterAndSortCompletionResponse(
     return;
   }
 
+  // make sure all items have |filterText| set, code that follow needs it
+  for (auto& item : items) {
+    if (item.filterText.empty()) {
+      item.filterText = item.label;
+    }
+  }
+
   // If the text doesn't start with underscore,
   // remove all candidates that start with underscore.
   if (!complete_text.empty() && complete_text[0] != '_') {
     auto filter = [](const lsCompletionItem& item) {
-      return item.label[0] == '_';
+      return item.filterText[0] == '_';
     };
     items.erase(std::remove_if(items.begin(), items.end(), filter),
                 items.end());
@@ -142,7 +148,7 @@ void FilterAndSortCompletionResponse(
   // Fuzzy match.
   for (auto& item : items)
     std::tie(item.found_, item.skip_) =
-        SubsequenceCountSkip(complete_text, item.label);
+        SubsequenceCountSkip(complete_text, item.filterText);
 
   // Order all items and set |sortText|.
   std::sort(items.begin(), items.end(), CompareLsCompletionItem);


### PR DESCRIPTION
First,
Thanks for cquery, this is a very promising project!

I'd like to propose some changes to the completion results.
You can find attached to this PR a draft implementation,
if you want to try it out.
I will be willing to clean it if there is interest in the changes I propose.

First, a list of the few things that I think could be improved:
- The detail, which is the full signature, repeats the name of the candidate.
  This is mostly annoying an issue when the detail is "inline" (<kbd>Ctrl + Space</kbd> in VS Code).
- In C++, it's possible to have multiple function with the same name,
  but different arguments,
  it is interesting to be able to pick up the right function at a glimpse,
  with the snippet completing the arguments.

My solutions:
- Show the contextual parent of the candidate in the details,
  this is a new information we didn't have before.
- Show the function/variable signature instead simple identifier for the label.
  This allow one to pick up the right signature directly.
- Expand default arguments into multiple items,
  so that you can pick up the right signature directly,
  the same way you do with overloaded functions.

Before/After on custom/simplified struct:

![image](https://user-images.githubusercontent.com/424046/35697445-8bb65d3a-078a-11e8-832a-ddd7474c7849.png)
![image](https://user-images.githubusercontent.com/424046/35698290-e19d2650-078c-11e8-8346-107cb07c6444.png)

Before/After with STL, heavy on the signature:

![image](https://user-images.githubusercontent.com/424046/35697719-4e5913aa-078b-11e8-9f85-860c1b283051.png)
![image](https://user-images.githubusercontent.com/424046/35698240-bfb6ecf6-078c-11e8-8852-1e4c83f7e981.png)



For reference, the boilerplate code I used for quick testing:

```cpp
#include <string>

struct Abc {
  /// A function with 2 defaults arguments.
  void defarg(int a = 0, int b = 0);

  /// This overload takes an integer.
  void overloaded(int x);

  /// This overload takes a double.
  void overloaded(double x);

  int foobiz = 42;
};

void someFn(std::string &s) {
   
}
```

What do you think?
If you are positive, I will be glad to cleanup the PR for proper submission.
