### PR TITLE
 Look for .cquery in any directory above the source file in the hierarchy.

### DIFF
--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -44,7 +44,6 @@ std::string GetWorkingDirectory() {
 std::string NormalizePath(const std::string& path) {
   DWORD retval = 0;
   TCHAR buffer[MAX_PATH] = TEXT("");
-  TCHAR buf[MAX_PATH] = TEXT("");
   TCHAR** lpp_part = {NULL};
 
   retval = GetFullPathName(path.c_str(), MAX_PATH, buffer, lpp_part);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -120,6 +120,15 @@ bool FindAnyPartial(const std::string& value,
                      });
 }
 
+std::string GetDirName(std::string path) {
+  if (path.size() && path.back() == '/')
+    path.pop_back();
+  size_t last_slash = path.find_last_of('/');
+  if (last_slash == std::string::npos) return ".";
+  if (last_slash == 0) return "/";
+  return path.substr(0, last_slash);
+}
+
 std::string GetBaseName(const std::string& path) {
   size_t last_slash = path.find_last_of('/');
   if (last_slash != std::string::npos && (last_slash + 1) < path.size())
@@ -205,14 +214,14 @@ static void GetFilesInFolderHelper(
         goto bail;
       }
 
-      // Skip all dot files.
+      // Skip all dot files except .cquery.
       //
       // The nested ifs are intentional, branching order is subtle here.
       //
       // Note that in the future if we do support dot directories/files, we must
       // always ignore the '.' and '..' directories otherwise this will loop
       // infinitely.
-      if (file.name[0] != '.') {
+      if (file.name[0] != '.' || strcmp(file.name, ".cquery") == 0) {
         if (file.is_dir) {
           if (recursive) {
             std::string child_dir = q.front().second + file.name + "/";

--- a/src/utils.h
+++ b/src/utils.h
@@ -33,7 +33,8 @@ bool EndsWithAny(const std::string& value,
                  const std::vector<std::string>& endings);
 bool FindAnyPartial(const std::string& value,
                     const std::vector<std::string>& values);
-
+// Returns the dirname of |path|, i.e. "foo/bar.cc" => "foo", "foo" => ".", "/foo" => "/".
+std::string GetDirName(std::string path);
 // Returns the basename of |path|, ie, "foo/bar.cc" => "bar.cc".
 std::string GetBaseName(const std::string& path);
 // Returns |path| without the filetype, ie, "foo/bar.cc" => "foo/bar".


### PR DESCRIPTION
Currently cquery only reads compiler arguments (.cquery) from project root. 
Under some circumstances (e.g. remote compiling), generating a compilation database with correct path in it is non-trivial, and allowing per directory compile arguments usually helps.