### PR TITLE
wscript fixes for Windows

### DIFF
--- a/wscript
+++ b/wscript
@@ -309,7 +309,7 @@ def configure(ctx):
         dst = os.path.join(ctx.path.get_bld().abspath(), 'lib', name, 'bin', 'libclang.dll')
         os.symlink(dst, out_clang_dll)
       except (OSError, NotImplementedError):
-        shutil.copy(dst, out_clang_dll)
+        shutil.copy(out_clang_dll, dst)
     else:
       ctx.env.rpath = ctx.env['LIBPATH_clang']
 


### PR DESCRIPTION
- Fixes wscript so symbolic link creation doesn't fail if Developer Mode is enabled
- Fixes arguments order to shutil.copy if symbolic link creation fails
- wscript now uses unicode version of CreateSymbolicLink (W suffix) and always passes unicode strings to that function