### PR TITLE
Match directory before looking at included files.

### DIFF
--- a/src/include_complete.cc
+++ b/src/include_complete.cc
@@ -161,6 +161,10 @@ void IncludeComplete::InsertIncludesFromDirectory(std::string directory,
                                                   bool use_angle_brackets) {
   directory = NormalizePath(directory);
   EnsureEndsInSlash(directory);
+  if (match_ && !match_->IsMatch(directory)) {
+    // Don't even enter the directory if it fails the patterns.
+    return;
+  }
 
   std::vector<CompletionCandidate> results;
   GetFilesInFolder(


### PR DESCRIPTION
Greetings, I have a folder with a ton of generated files I want to blacklist from include completion, so I would like  to check the directory for a match first before running the match against every file.