### PR TITLE
Fix a bunch of stuffs in completion.

### DIFF
--- a/src/include_complete.h
+++ b/src/include_complete.h
@@ -27,17 +27,22 @@ struct IncludeComplete {
   optional<lsCompletionItem> FindCompletionItemForAbsolutePath(
       const std::string& absolute_path);
 
+  // Insert item to |completion_items|.
+  // Update |absolute_path_to_completion_item| and |inserted_paths|.
+  void InsertCompletionItem(const std::string& absolute_path,
+                            lsCompletionItem&& item);
+
   // Guards |completion_items| when |is_scanning| is true.
   std::mutex completion_items_mutex;
   std::atomic<bool> is_scanning;
   std::vector<lsCompletionItem> completion_items;
 
-  // Absolute file path to the completion item in |completion_items|. Also
-  // verifies that we only have one completion item per absolute path.
-  // We cannot just scan |completion_items| for this information because the
-  // same path can often be epxressed in mutliple ways; a trivial example is
-  // angle vs quote include style (ie, <foo> vs "foo").
+  // Absolute file path to the completion item in |completion_items|.
+  // Keep the one with shortest include path.
   std::unordered_map<std::string, int> absolute_path_to_completion_item;
+
+  // Only one completion item per include path.
+  std::unordered_map<std::string, int> inserted_paths;
 
   // Cached references
   Config* config_;

--- a/src/language_server_api.h
+++ b/src/language_server_api.h
@@ -351,12 +351,15 @@ struct lsCompletionItem {
   std::string detail;
 
   // A human-readable string that represents a doc-comment.
-  std::string documentation;
+  optional<std::string> documentation;
 
   // Internal information to order candidates.
   bool found_;
   std::string::size_type skip_;
   unsigned priority_;
+
+  // Use <> or "" by default as include path.
+  bool use_angle_brackets_ = false;
 
   // A string that shoud be used when comparing this item
   // with other items. When `falsy` the label is used.

--- a/src/lex_utils.cc
+++ b/src/lex_utils.cc
@@ -64,22 +64,25 @@ ParseIncludeLineResult ParseIncludeLine(const std::string& line) {
 
 void DecorateIncludePaths(const std::smatch& match,
                           std::vector<lsCompletionItem>* items) {
-  char quote0, quote1;
-  if (match[5].compare("\"") == 0)
-    quote0 = quote1 = '"';
-  else
-    quote0 = '<', quote1 = '>';
+  std::string spaces_after_include = " ";
+  if (match[3].compare("include") == 0 && match[5].length())
+    spaces_after_include = match[4].str();
 
-  std::string spaces_between_include_and_quote =
-      match[3].compare("include") == 0 ? match[4].str() : " ";
-
-  std::string prefix = match[1].str() + '#' + match[2].str() + "include" +
-                       spaces_between_include_and_quote + quote0;
-  std::string suffix = std::string(1, quote1) + match[7].str();
+  std::string prefix =
+      match[1].str() + '#' + match[2].str() + "include" + spaces_after_include;
+  std::string suffix = match[7].str();
 
   for (lsCompletionItem& item : *items) {
-    item.textEdit->newText = prefix + item.textEdit->newText + suffix;
-    item.label = prefix + item.label + suffix;
+    char quote0, quote1;
+    if (match[5].compare("<") == 0 ||
+        (match[5].length() == 0 && item.use_angle_brackets_))
+      quote0 = '<', quote1 = '>';
+    else
+      quote0 = quote1 = '"';
+
+    item.textEdit->newText =
+        prefix + quote0 + item.textEdit->newText + quote1 + suffix;
+    item.label = prefix + quote0 + item.label + quote1 + suffix;
     item.filterText = nullopt;
   }
 }


### PR DESCRIPTION
1. Each item has its default option between angle bracket and quote.
2. Better duplicate handling using include path instead of absolute path.
3. Make `documentation` optional to save json size.
4. Completion at `#include<cursor>` has a space after `include`.
 