### PR TITLE
Making completion_request_ ThreadedQueue from AtomicObject

### DIFF
--- a/src/clang_complete.h
+++ b/src/clang_complete.h
@@ -55,6 +55,13 @@ struct ClangCompleteManager {
     std::string path;
   };
   struct CompletionRequest {
+    CompletionRequest(const lsTextDocumentIdentifier& document,
+                      const bool& emit_diagnostics);
+    CompletionRequest(const lsTextDocumentIdentifier& document,
+                      const lsPosition& position,
+                      const OnComplete& on_complete,
+                      const bool& emit_diagnostics);
+
     lsTextDocumentIdentifier document;
     optional<lsPosition> position;
     OnComplete on_complete;  // May be null/empty.
@@ -120,7 +127,7 @@ struct ClangCompleteManager {
   std::mutex sessions_lock_;
 
   // Request a code completion at the given location.
-  AtomicObject<CompletionRequest> completion_request_;
+  ThreadedQueue<std::unique_ptr<CompletionRequest>> completion_request_;
   // Parse requests. The path may already be parsed, in which case it should be
   // reparsed.
   ThreadedQueue<ParseRequest> parse_requests_;


### PR DESCRIPTION
As I was trying out cquery as a shared service I noticed some of the autocomplete requests were dropped.

This would be an issue because vscode-jsonrpc accumulates unresponded messages in a hash-table.

In the previous releases I've noticed ```TryEnsureDocumentParsed``` was taking the longest time in completequery.  From 368b266 onwards it seem to have improved significantly. So responding to all completion requests might not be a very expensive operation