### PR TITLE
Fix libclang generic error on Windows

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -23,7 +23,6 @@
 #include <sstream>
 #include <unordered_set>
 #include <vector>
-#include <iostream>
 
 struct CompileCommandsEntry {
   std::string directory;

--- a/src/project.cc
+++ b/src/project.cc
@@ -1482,19 +1482,20 @@ TEST_SUITE("Project") {
   }
 
   TEST_CASE("IsWindowsAbsolutePath works correctly") {
-    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects/") == true);
-    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects") == true);
-    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects") == true);
-    REQUIRE(IsWindowsAbsolutePath("C:\\Users\\projects") == true);
-    REQUIRE(IsWindowsAbsolutePath("C:\\\\Users\\\\projects") == true);
-    REQUIRE(IsWindowsAbsolutePath("c:\\\\Users\\\\projects") == true);
-    REQUIRE(IsWindowsAbsolutePath("A:\\\\Users\\\\projects") == true);
+    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects/"));
+    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects"));
+    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects"));
+    REQUIRE(IsWindowsAbsolutePath("C:\\Users\\projects"));
+    REQUIRE(IsWindowsAbsolutePath("C:\\\\Users\\\\projects"));
+    REQUIRE(IsWindowsAbsolutePath("c:\\\\Users\\\\projects"));
+    REQUIRE(IsWindowsAbsolutePath("A:\\\\Users\\\\projects"));
 
-    REQUIRE(IsWindowsAbsolutePath("C:/") == false);
-    REQUIRE(IsWindowsAbsolutePath("../abc/test") == false);
-    REQUIRE(IsWindowsAbsolutePath("5:/test") == false);
-    REQUIRE(IsWindowsAbsolutePath("cquery/project/file.cc") == false);
-    REQUIRE(IsWindowsAbsolutePath("") == false);
+    REQUIRE(!IsWindowsAbsolutePath("C:/"));
+    REQUIRE(!IsWindowsAbsolutePath("../abc/test"));
+    REQUIRE(!IsWindowsAbsolutePath("5:/test"));
+    REQUIRE(!IsWindowsAbsolutePath("cquery/project/file.cc"));
+    REQUIRE(!IsWindowsAbsolutePath(""));
+    REQUIRE(!IsWindowsAbsolutePath("/etc/linux/path"));
   }
 
   TEST_CASE("Entry inference prefers same file endings") {

--- a/src/project.cc
+++ b/src/project.cc
@@ -53,7 +53,8 @@ bool IsWindowsAbsolutePath(const std::string& path) {
     return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
   };
 
-  return path.size() > 3 && path[1] == ':' && path[2] == '/' &&
+  return path.size() > 3 && path[1] == ':' && 
+         (path[2] == '/' || path[2] == '\\') &&
          is_drive_letter(path[0]);
 }
 

--- a/src/project.cc
+++ b/src/project.cc
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <vector>
+#include <iostream>
 
 struct CompileCommandsEntry {
   std::string directory;
@@ -1478,6 +1479,22 @@ TEST_SUITE("Project") {
       REQUIRE(entry.has_value());
       REQUIRE(entry->args == std::vector<std::string>{"a", "b", "ee.cc", "d"});
     }
+  }
+
+  TEST_CASE("IsWindowsAbsolutePath works correctly") {
+    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects/") == true);
+    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects") == true);
+    REQUIRE(IsWindowsAbsolutePath("C:/Users/projects") == true);
+    REQUIRE(IsWindowsAbsolutePath("C:\\Users\\projects") == true);
+    REQUIRE(IsWindowsAbsolutePath("C:\\\\Users\\\\projects") == true);
+    REQUIRE(IsWindowsAbsolutePath("c:\\\\Users\\\\projects") == true);
+    REQUIRE(IsWindowsAbsolutePath("A:\\\\Users\\\\projects") == true);
+
+    REQUIRE(IsWindowsAbsolutePath("C:/") == false);
+    REQUIRE(IsWindowsAbsolutePath("../abc/test") == false);
+    REQUIRE(IsWindowsAbsolutePath("5:/test") == false);
+    REQUIRE(IsWindowsAbsolutePath("cquery/project/file.cc") == false);
+    REQUIRE(IsWindowsAbsolutePath("") == false);
   }
 
   TEST_CASE("Entry inference prefers same file endings") {


### PR DESCRIPTION
See https://github.com/cquery-project/cquery/issues/491

This pull request does not fix the wrongly formatted command printed when the libclang generic error happens. It just stops the error from happening. 