### PR TITLE
Make CL mode detection fool-proof

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -158,9 +158,22 @@ Project::Entry GetCompilationEntryFromCompileCommandEntry(
   if (args.empty())
     return result;
 
-  bool clang_cl = strstr(args[0].c_str(), "clang-cl") ||
-                  strstr(args[0].c_str(), "cl.exe") ||
-                  AnyStartsWith(args, "--driver-mode=cl");
+  std::string first_arg = args[0];
+  // Windows' filesystem is not case sensitive, so we compare only
+  // the lower case variant.
+  std::transform(first_arg.begin(), first_arg.end(), first_arg.begin(),
+                 tolower);
+  bool clang_cl = strstr(first_arg.c_str(), "clang-cl") ||
+                  strstr(first_arg.c_str(), "cl.exe");
+  // Clang only cares about the last --driver-mode flag, so the loop
+  // iterates in reverse to find the last one as soon as possible
+  // in case of multiple --driver-mode flags.
+  for (int i = args.size() - 1; i >= 0; --i) {
+    if (strstr(args[i].c_str(), "--dirver-mode=")) {
+      clang_cl = clang_cl || strstr(args[i].c_str(), "--driver-mode=cl");
+      break;
+    }
+  }
   size_t i = 1;
 
   // If |compilationDatabaseCommand| is specified, the external command provides


### PR DESCRIPTION
As discussed with @MaskRay the clang CL driver detection isn't fool proof for two reasons.

- Windows' paths are case-insensitive.
- Multiple `--driver-mode` flags are allowed.

Some thing like `C:\\Program Files\\LLVM\\bin\\ClanG-Cl.eXe  --driver-mode=gcc --driver-mode=cl --driver-mode=gcc` does the following:

- `ClanG-Cl.eXe` implicitly means CL mode.
- `--driver-mode=gcc` overrides it and explicitly sets GCC mode.
- `--driver-mode=cl` overrides it and once again sets CL mode.
- `--driver-mode=gcc` finally sets the mode to GCC.

On the other hand, cquery right now does the following:

- `clang-cl` isn't found, so we are not in CL mode. - This is wrong.
- There's at least one `--driver-mode=cl` flag, so we definitely are in CL mode. - Once again wrong.

This PR changes the code to check the clang driver mode in the following fashion:

- Check if the lowercase representation of the first flag contains `clang-cl` or `cl.exe`.
- Iterate over the flags in reverse to find the last occurrence of `--driver-mode=`.
  - Once found, check if it is `--driver-mode=cl` and do a logical or with the result of thte first check.

For what it's worth, this is almost exactly how ycmd checks for CL driver mode. The difference being that ycmd uses regex to match the compiler.