### PR TITLE
Add -idirafter to kPathArgs

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -86,7 +86,9 @@ std::vector<std::string> kBlacklist = {
 std::vector<std::string> kPathArgs = {
     "-I",        "-iquote",        "-isystem",     "--sysroot=",
     "-isysroot", "-gcc-toolchain", "-include-pch", "-iframework",
-    "-F",        "-imacros",       "-include",     "/I"};
+    "-F",        "-imacros",       "-include",     "/I",
+    "-idirafter"
+};
 
 // Arguments which always require an absolute path, ie, clang -working-directory
 // does not work as expected. Argument processing assumes that this is a subset


### PR DESCRIPTION
Apparently, people use [`-idirafter`](https://github.com/Valloric/ycmd/issues/874) too.

Note that this doesn't make an exhaustive list of include path flags, but it does make the list contain all the flags the users have encountered over the years, as far as ycmd is concerned.