### PR TITLE
[RFC] Conditionally allow reindex on didChange

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -212,6 +212,10 @@ struct Config {
     bool sort = true;
   } workspaceSymbol;
 
+  // Allow indexing on textDocument/didChange.
+  // May be too slow for big projects, so it is off by default.
+  bool enableIndexOnDidChange = false;
+
   struct Xref {
     // If true, |Location[]| response will include lexical container.
     bool container = false;
@@ -274,6 +278,8 @@ MAKE_REFLECT_STRUCT(Config,
                     index,
                     workspaceSymbol,
                     xref,
+                    
+                    enableIndexOnDidChange,
 
                     dumpAST);
 


### PR DESCRIPTION
Like I mentioned in the gitter room, I wasn't able to put this to the test, though it looks like a straight forward way to do this.

Reason why there isn't a test for this is that I'm not sure how to make one.
The test would need to do the following:

- Index a file once.
- Make a change to that file.
- Make a change to the file, but not save it because we don't want to trigger reindexing on `didSave`.
- Fire a `textDocument/didChange` message.
- Reindex again.
- Assert the new index differs.
- Nothing to undo the change to the file, because the change shouldn't have been saved.

I'm just not sure how to make such a test for cquery.

Before this is marked `[READY]` let's consider turning off reindexing on `didSave` if we do it on `didChange`. From where I stand, the last `didChange` would happen before the last `didSave` with no possible changes to the file in between and thus no changes to the index. This is also the reason why ycmd never implmented `didSave` message.