### PR TITLE
Make overridden flags persistent after didSave

### DIFF
--- a/src/messages/text_document_did_open.cc
+++ b/src/messages/text_document_did_open.cc
@@ -61,7 +61,7 @@ struct TextDocumentDidOpenHandler
     clang_complete->NotifyView(path);
 
     // Submit new index request.
-    const Project::Entry& entry = project->FindCompilationEntryForFile(path);
+    Project::Entry entry = project->FindCompilationEntryForFile(path);
     QueueManager::instance()->index_request.PushBack(
         Index_Request(
             entry.filename, params.args.size() ? params.args : entry.args,
@@ -70,6 +70,9 @@ struct TextDocumentDidOpenHandler
 
     clang_complete->FlushSession(entry.filename);
     LOG_S(INFO) << "Flushed clang complete sessions for " << entry.filename;
+    if (params.args.size()) {
+      project->SetFlagsForFile(params.args, path);
+    }
   }
 };
 REGISTER_MESSAGE_HANDLER(TextDocumentDidOpenHandler);

--- a/src/project.cc
+++ b/src/project.cc
@@ -569,6 +569,23 @@ void Project::Load(Config* config, const std::string& root_directory) {
     absolute_path_to_entry_index_[entries[i].filename] = i;
 }
 
+void Project::SetFlagsForFile(
+    const std::vector<std::string>& flags,
+    const std::string& path) {
+  auto it = absolute_path_to_entry_index_.find(path);
+  if (it != absolute_path_to_entry_index_.end()) {
+    // The entry already exists in the project, just set the flags.
+    this->entries[it->second].args = flags;
+  } else {
+    // Entry wasn't found, so we create a new one.
+    Entry entry;
+    entry.is_inferred = false;
+    entry.filename = path;
+    entry.args = flags;
+    this->entries.emplace_back(entry);
+  }
+}
+
 Project::Entry Project::FindCompilationEntryForFile(
     const std::string& filename) {
   auto it = absolute_path_to_entry_index_.find(filename);

--- a/src/project.h
+++ b/src/project.h
@@ -48,6 +48,13 @@ struct Project {
   // will infer one based on existing project structure.
   Entry FindCompilationEntryForFile(const std::string& filename);
 
+  // If the client has overridden the flags, or specified them for a file
+  // that is not in the compilation_database.json make sure those changes
+  // are permanent.
+  void SetFlagsForFile(
+      const std::vector<std::string>& flags,
+      const std::string& path);
+
   // Run |action| on every file in the project.
   void ForAllFilteredFiles(
       Config* config,


### PR DESCRIPTION
didOpen can override flags from compilation database.
didSave was able to reset the flags back.
This makes sure that the overridden flags persist.

Fixes #541