### PR TITLE
Ignore cl's -showIncludes

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -80,7 +80,7 @@ std::vector<std::string> kBlacklistMulti = {
 
 // Blacklisted flags which are always removed from the command line.
 std::vector<std::string> kBlacklist = {
-    "-c", "-MP", "-MD", "-MMD", "--fcolor-diagnostics",
+    "-c", "-MP", "-MD", "-MMD", "--fcolor-diagnostics", "-showIncludes"
 };
 
 // Arguments which are followed by a potentially relative path. We need to make


### PR DESCRIPTION
Fixes #544.

I'm not sure whether `/showIncludes` should also be included in that list, because cl.exe allow all flags to be passed with either `/` or `-`.