### PR TITLE
UB fixed.

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -63,7 +63,6 @@ bool ShouldDisplayMethodTiming(MethodType type) {
     type != kMethodType_TextDocumentPublishDiagnostics &&
     type != kMethodType_CqueryPublishInactiveRegions &&
     type != kMethodType_Unknown;
-  return true;
 }
 
 void PrintHelp() {

--- a/src/method.h
+++ b/src/method.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-using MethodType = std::string;
+using MethodType = const char*;
 extern MethodType kMethodType_Unknown;
 extern MethodType kMethodType_Exit;
 extern MethodType kMethodType_TextDocumentPublishDiagnostics;


### PR DESCRIPTION
As I remember - construction order of global variables is not specified. Them only must be initialized before main. So it's quite bad idea to have non static inter module constants which initialization can't be moved to .data section.

Anyway without this fix cquery crashed on debian jessie with following stack trace:

```
Program received signal SIGSEGV, Segmentation fault.          
0x00007ffff3a2d26b in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::string const&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
(gdb) bt                                                      
#0  0x00007ffff3a2d26b in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::string const&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x000000000045b74b in _GLOBAL__sub_I_exit.cc () at ../../src/messages/exit.cc:7                                         
#2  0x00000000006115dd in __libc_csu_init ()                  
#3  0x00007ffff30ccad5 in __libc_start_main (main=0x494bb0 <main(int, char**)>, argc=1, argv=0x7fffffffea78, init=0x611590 <__libc_csu_init>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffea68) at libc-start.c:246
#4  0x0000000000465096 in _start ()   
```

Also forgotten return was removed.