### PR TITLE
Use textEdit for completions

### DIFF
--- a/src/messages/text_document_completion.cc
+++ b/src/messages/text_document_completion.cc
@@ -308,10 +308,11 @@ struct Handler_TextDocumentCompletion : MessageHandler {
 
     bool is_global_completion = false;
     std::string existing_completion;
+    lsPosition end_pos = request->params.position;
     if (file) {
       request->params.position = file->FindStableCompletionSource(
           request->params.position, &is_global_completion,
-          &existing_completion);
+          &existing_completion, &end_pos);
     }
 
     ParseIncludeLineResult result = ParseIncludeLine(buffer_line);
@@ -355,7 +356,7 @@ struct Handler_TextDocumentCompletion : MessageHandler {
       QueueManager::WriteStdout(kMethodType, out);
     } else {
       ClangCompleteManager::OnComplete callback = std::bind(
-          [this, is_global_completion, existing_completion, request](
+          [this, is_global_completion, existing_completion, end_pos, request](
               const std::vector<lsCompletionItem>& results,
               bool is_cached_result) {
             Out_TextDocumentComplete out;
@@ -365,6 +366,13 @@ struct Handler_TextDocumentCompletion : MessageHandler {
             // Emit completion results.
             FilterAndSortCompletionResponse(&out, existing_completion,
                                             config->completion.filterAndSort);
+            // Change inserts to edits.
+            for (auto& item : out.result.items) {
+              if (!item.insertText.empty()) {
+                item.textEdit = lsTextEdit{lsRange(request->params.position, end_pos), ""};
+                item.textEdit->newText.swap(item.insertText);
+              }
+            }
             QueueManager::WriteStdout(kMethodType, out);
 
             // Cache completion results.

--- a/src/working_files.cc
+++ b/src/working_files.cc
@@ -407,7 +407,8 @@ std::string WorkingFile::FindClosestCallNameInBuffer(
 lsPosition WorkingFile::FindStableCompletionSource(
     lsPosition position,
     bool* is_global_completion,
-    std::string* existing_completion) const {
+    std::string* existing_completion,
+    lsPosition* replace_end_position) const {
   *is_global_completion = true;
 
   int start_offset = GetOffsetForPosition(position, buffer_content);
@@ -431,6 +432,16 @@ lsPosition WorkingFile::FindStableCompletionSource(
       break;
     }
     --offset;
+  }
+
+  *replace_end_position = position;
+  int end_offset = start_offset;
+  while (end_offset < buffer_content.size()) {
+    char c = buffer_content[end_offset];
+    if (!isalnum(c) && c != '_') break;
+    ++end_offset;
+    // We know that replace_end_position and position are on the same line.
+    ++replace_end_position->character;
   }
 
   *existing_completion = buffer_content.substr(offset, start_offset - offset);
@@ -612,40 +623,58 @@ TEST_SUITE("WorkingFile") {
   }
 
   TEST_CASE("existing completion") {
-    WorkingFile f("foo.cc", "zzz.asdf");
+    WorkingFile f("foo.cc", "zzz.asdf ");
     bool is_global_completion;
     std::string existing_completion;
+    lsPosition end_pos;
 
     f.FindStableCompletionSource(CharPos(f, '.'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "zzz");
+    REQUIRE(end_pos.line == CharPos(f, '.').line);
+    REQUIRE(end_pos.character == CharPos(f, '.').character);
     f.FindStableCompletionSource(CharPos(f, 'a', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "a");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 's', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "as");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 'd', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "asd");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 'f', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "asdf");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
   }
 
   TEST_CASE("existing completion underscore") {
-    WorkingFile f("foo.cc", "ABC_DEF");
+    WorkingFile f("foo.cc", "ABC_DEF ");
     bool is_global_completion;
     std::string existing_completion;
+    lsPosition end_pos;
 
     f.FindStableCompletionSource(CharPos(f, 'C'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "AB");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, '_'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "ABC");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 'D'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "ABC_");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
   }
 }

--- a/src/working_files.h
+++ b/src/working_files.h
@@ -67,9 +67,12 @@ struct WorkingFile {
   // global completion.
   // The out param |existing_completion| is set to any existing completion
   // content the user has entered.
+  // The out param |replace_end_position| is set to the end of the existing
+  // identifier, including characters after the original position.
   lsPosition FindStableCompletionSource(lsPosition position,
                                         bool* is_global_completion,
-                                        std::string* existing_completion) const;
+                                        std::string* existing_completion,
+                                        lsPosition* replace_end_position) const;
 
  private:
   // Compute index_to_buffer and buffer_to_index.


### PR DESCRIPTION
Rather than just inserting text for completions, use textEdit to insert
text which replaces the entire identifier, including text after the
cursor.