### PR TITLE
Fixed newlines in error message

### DIFF
--- a/src/lsp.cc
+++ b/src/lsp.cc
@@ -51,7 +51,7 @@ optional<std::string> ReadJsonRpcContentFrom(
     return opt_c && *opt_c == expected;
   };
   if (!expect_char('\r') || !expect_char('\n')) {
-    LOG_S(INFO) << "Unexpected token (expected \r\n sequence)";
+    LOG_S(INFO) << "Unexpected token (expected \\r\\n sequence)";
     return nullopt;
   }
 


### PR DESCRIPTION
Output the escape sequence instead of the newline.