### PR TITLE
Use range for completions

### DIFF
--- a/src/include_complete.cc
+++ b/src/include_complete.cc
@@ -83,8 +83,7 @@ lsCompletionItem BuildCompletionItem(Config* config,
   lsCompletionItem item;
   item.label = ElideLongPath(config, path);
   item.detail = path;  // the include path, used in de-duplicating
-  item.textEdit = lsTextEdit();
-  item.textEdit->newText = path;
+  item.insertText = path;
   item.insertTextFormat = lsInsertTextFormat::PlainText;
   item.use_angle_brackets_ = use_angle_brackets;
   if (is_stl) {

--- a/src/lsp_completion.h
+++ b/src/lsp_completion.h
@@ -94,12 +94,17 @@ struct lsCompletionItem {
   // property and the `newText` property of a provided `textEdit`.
   lsInsertTextFormat insertTextFormat = lsInsertTextFormat::PlainText;
 
-  // An edit which is applied to a document when selecting this completion. When
-  // an edit is provided the value of `insertText` is ignored.
+  // A range of text that should be replaced by this completion item.
   //
-  // *Note:* The range of the edit must be a single line range and it must
-  // contain the position at which completion has been requested.
-  optional<lsTextEdit> textEdit;
+  // Defaults to a range from the start of the current word to the current
+  // position.
+  //
+  // *Note:* The range must be a single line and it must contain the position at
+  // which completion has been requested.
+  optional<lsRange> range;
+
+  // deprecated - Use CompletionItem.insertText and CompletionItem.range instead.
+  // optional<lsTextEdit> textEdit;
 
   // An optional array of additional text edits that are applied when
   // selecting this completion. Edits must not overlap with the main edit
@@ -115,11 +120,8 @@ struct lsCompletionItem {
   // data ? : any
 
   // Use this helper to figure out what content the completion item will insert
-  // into the document, as it could live in either |textEdit|, |insertText|, or
-  // |label|.
+  // into the document, as it could live in either |insertText| or |label|.
   const std::string& InsertedContent() const {
-    if (textEdit)
-      return textEdit->newText;
     if (!insertText.empty())
       return insertText;
     return label;
@@ -134,4 +136,4 @@ MAKE_REFLECT_STRUCT(lsCompletionItem,
                     insertText,
                     filterText,
                     insertTextFormat,
-                    textEdit);
+                    range);

--- a/src/messages/text_document_code_action.cc
+++ b/src/messages/text_document_code_action.cc
@@ -481,9 +481,7 @@ struct Handler_TextDocumentCodeAction
               include_complete->FindCompletionItemForAbsolutePath(path);
           if (!item)
             continue;
-          if (item->textEdit)
-            include_insert_strings.insert(item->textEdit->newText);
-          else if (!item->insertText.empty())
+          if (!item->insertText.empty())
             include_insert_strings.insert(item->insertText);
           else {
             // FIXME https://github.com/cquery-project/cquery/issues/463

--- a/src/working_files.cc
+++ b/src/working_files.cc
@@ -407,7 +407,8 @@ std::string WorkingFile::FindClosestCallNameInBuffer(
 lsPosition WorkingFile::FindStableCompletionSource(
     lsPosition position,
     bool* is_global_completion,
-    std::string* existing_completion) const {
+    std::string* existing_completion,
+    lsPosition* replace_end_position) const {
   *is_global_completion = true;
 
   int start_offset = GetOffsetForPosition(position, buffer_content);
@@ -431,6 +432,16 @@ lsPosition WorkingFile::FindStableCompletionSource(
       break;
     }
     --offset;
+  }
+
+  *replace_end_position = position;
+  int end_offset = start_offset;
+  while (end_offset < buffer_content.size()) {
+    char c = buffer_content[end_offset];
+    if (!isalnum(c) && c != '_') break;
+    ++end_offset;
+    // We know that replace_end_position and position are on the same line.
+    ++replace_end_position->character;
   }
 
   *existing_completion = buffer_content.substr(offset, start_offset - offset);
@@ -612,40 +623,58 @@ TEST_SUITE("WorkingFile") {
   }
 
   TEST_CASE("existing completion") {
-    WorkingFile f("foo.cc", "zzz.asdf");
+    WorkingFile f("foo.cc", "zzz.asdf ");
     bool is_global_completion;
     std::string existing_completion;
+    lsPosition end_pos;
 
     f.FindStableCompletionSource(CharPos(f, '.'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "zzz");
+    REQUIRE(end_pos.line == CharPos(f, '.').line);
+    REQUIRE(end_pos.character == CharPos(f, '.').character);
     f.FindStableCompletionSource(CharPos(f, 'a', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "a");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 's', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "as");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 'd', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "asd");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 'f', 1), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "asdf");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
   }
 
   TEST_CASE("existing completion underscore") {
-    WorkingFile f("foo.cc", "ABC_DEF");
+    WorkingFile f("foo.cc", "ABC_DEF ");
     bool is_global_completion;
     std::string existing_completion;
+    lsPosition end_pos;
 
     f.FindStableCompletionSource(CharPos(f, 'C'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "AB");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, '_'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "ABC");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
     f.FindStableCompletionSource(CharPos(f, 'D'), &is_global_completion,
-                                 &existing_completion);
+                                 &existing_completion, &end_pos);
     REQUIRE(existing_completion == "ABC_");
+    REQUIRE(end_pos.line == CharPos(f, ' ').line);
+    REQUIRE(end_pos.character == CharPos(f, ' ').character);
   }
 }

--- a/src/working_files.h
+++ b/src/working_files.h
@@ -67,9 +67,12 @@ struct WorkingFile {
   // global completion.
   // The out param |existing_completion| is set to any existing completion
   // content the user has entered.
+  // The out param |replace_end_position| is set to the end of the existing
+  // identifier, including characters after the original position.
   lsPosition FindStableCompletionSource(lsPosition position,
                                         bool* is_global_completion,
-                                        std::string* existing_completion) const;
+                                        std::string* existing_completion,
+                                        lsPosition* replace_end_position) const;
 
  private:
   // Compute index_to_buffer and buffer_to_index.


### PR DESCRIPTION
Rather than just inserting text for completions, use range to insert
text which replaces the entire identifier, including text after the
cursor.

Additionally, deprecates textEdit, and changes uses of textEdit to
uses of insertText + range.

Reland of #598, which keeps insertText and uses range instead of the
deprecated textEdit. This should keep non-compliant clients (that only
parse insertText) happy.