### PR TITLE
Revert "Use range for completions"

### DIFF
--- a/src/include_complete.cc
+++ b/src/include_complete.cc
@@ -83,7 +83,8 @@ lsCompletionItem BuildCompletionItem(Config* config,
   lsCompletionItem item;
   item.label = ElideLongPath(config, path);
   item.detail = path;  // the include path, used in de-duplicating
-  item.insertText = path;
+  item.textEdit = lsTextEdit();
+  item.textEdit->newText = path;
   item.insertTextFormat = lsInsertTextFormat::PlainText;
   item.use_angle_brackets_ = use_angle_brackets;
   if (is_stl) {

--- a/src/lsp_completion.h
+++ b/src/lsp_completion.h
@@ -94,17 +94,12 @@ struct lsCompletionItem {
   // property and the `newText` property of a provided `textEdit`.
   lsInsertTextFormat insertTextFormat = lsInsertTextFormat::PlainText;
 
-  // A range of text that should be replaced by this completion item.
+  // An edit which is applied to a document when selecting this completion. When
+  // an edit is provided the value of `insertText` is ignored.
   //
-  // Defaults to a range from the start of the current word to the current
-  // position.
-  //
-  // *Note:* The range must be a single line and it must contain the position at
-  // which completion has been requested.
-  optional<lsRange> range;
-
-  // deprecated - Use CompletionItem.insertText and CompletionItem.range instead.
-  // optional<lsTextEdit> textEdit;
+  // *Note:* The range of the edit must be a single line range and it must
+  // contain the position at which completion has been requested.
+  optional<lsTextEdit> textEdit;
 
   // An optional array of additional text edits that are applied when
   // selecting this completion. Edits must not overlap with the main edit
@@ -120,8 +115,11 @@ struct lsCompletionItem {
   // data ? : any
 
   // Use this helper to figure out what content the completion item will insert
-  // into the document, as it could live in either |insertText| or |label|.
+  // into the document, as it could live in either |textEdit|, |insertText|, or
+  // |label|.
   const std::string& InsertedContent() const {
+    if (textEdit)
+      return textEdit->newText;
     if (!insertText.empty())
       return insertText;
     return label;
@@ -136,4 +134,4 @@ MAKE_REFLECT_STRUCT(lsCompletionItem,
                     insertText,
                     filterText,
                     insertTextFormat,
-                    range);
+                    textEdit);

--- a/src/messages/text_document_code_action.cc
+++ b/src/messages/text_document_code_action.cc
@@ -481,7 +481,9 @@ struct Handler_TextDocumentCodeAction
               include_complete->FindCompletionItemForAbsolutePath(path);
           if (!item)
             continue;
-          if (!item->insertText.empty())
+          if (item->textEdit)
+            include_insert_strings.insert(item->textEdit->newText);
+          else if (!item->insertText.empty())
             include_insert_strings.insert(item->insertText);
           else {
             // FIXME https://github.com/cquery-project/cquery/issues/463


### PR DESCRIPTION
This reverts commit 27db9f85dccc3ff4d4ac2eefab66dcb4f4b4c747.

"Range" is a vscode API property, not an LSP one.