### PR TITLE
Need to add pugixml to includes for clang_format.cc to compile

### DIFF
--- a/wscript
+++ b/wscript
@@ -384,6 +384,7 @@ def build(bld):
         'third_party/doctest/',
         'third_party/loguru/',
         'third_party/msgpack-c/include',
+        'third_party/pugixml/src/',
         'third_party/rapidjson/include/',
         'third_party/sparsepp/'] +
         (['libclang'] if bld.env['use_clang_cxx'] else []),


### PR DESCRIPTION
Otherwise the following error is seen and cquery fails to build:

```
[16/89] Compiling src/clang_format.cc
../../src/clang_format.cc:9:10: fatal error: pugixml.hpp: No such file or directory
 #include <pugixml.hpp>
          ^~~~~~~~~~~~~
compilation terminated.

Waf: Leaving directory `/home/alex/cquery/build/release'
Build failed
 -> task in 'bin/cquery' failed with exit status 1 (run with -v to display more information)
```