### PR TITLE
add `include-directory-after` to `kPathArgs`

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -176,7 +176,7 @@ std::vector<std::string> kPathArgs = {
     "-I",        "-iquote",        "-isystem",     "--sysroot=",
     "-isysroot", "-gcc-toolchain", "-include-pch", "-iframework",
     "-F",        "-imacros",       "-include",     "/I",
-    "-idirafter"};
+    "-idirafter", "--include-directory-after=", "--include-directory-after"};
 
 // Arguments which always require an absolute path, ie, clang -working-directory
 // does not work as expected. Argument processing assumes that this is a subset


### PR DESCRIPTION
as mentioned in https://github.com/cquery-project/cquery/issues/641 this is a less common form of the already handled `-idirafter`