### PR TITLE
Fix Building Error on macOS

### DIFF
--- a/src/method.cc
+++ b/src/method.cc
@@ -1,5 +1,6 @@
 #include "method.h"
 
+#include <iostream>
 #include <doctest/doctest.h>
 #include "serializers/json.h"
 


### PR DESCRIPTION
Fix the following building error on macOS.
```
Undefined symbols for architecture x86_64:
  "std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::operator<<<char, std::__1::char_traits<char>, std::__1::allocator<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      doctest::String doctest::detail::stringifyBinaryExpr<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, char [13]>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, char const*, char const (&) [13]) in method.cc.1.o
ld: symbol(s) not found for architecture x86_64
```

See more at https://github.com/onqtam/doctest/issues/126.

Fixes #649.