### PR TITLE
Fix LSP json responses for some methods

### DIFF
--- a/src/messages/cquery_call_hierarchy.cc
+++ b/src/messages/cquery_call_hierarchy.cc
@@ -74,7 +74,10 @@ MAKE_REFLECT_STRUCT(Out_CqueryCallHierarchy::Entry,
                     callType,
                     numChildren,
                     children);
-MAKE_REFLECT_STRUCT(Out_CqueryCallHierarchy, jsonrpc, id, result);
+MAKE_REFLECT_STRUCT_OPTIONALS_MANDATORY(Out_CqueryCallHierarchy,
+                                        jsonrpc,
+                                        id,
+                                        result);
 
 bool Expand(MessageHandler* m,
             Out_CqueryCallHierarchy::Entry* entry,

--- a/src/messages/cquery_inheritance_hierarchy.cc
+++ b/src/messages/cquery_inheritance_hierarchy.cc
@@ -58,7 +58,10 @@ MAKE_REFLECT_STRUCT(Out_CqueryInheritanceHierarchy::Entry,
                     location,
                     numChildren,
                     children);
-MAKE_REFLECT_STRUCT(Out_CqueryInheritanceHierarchy, jsonrpc, id, result);
+MAKE_REFLECT_STRUCT_OPTIONALS_MANDATORY(Out_CqueryInheritanceHierarchy,
+                                        jsonrpc,
+                                        id,
+                                        result);
 
 bool Expand(MessageHandler* m,
             Out_CqueryInheritanceHierarchy::Entry* entry,

--- a/src/messages/cquery_member_hierarchy.cc
+++ b/src/messages/cquery_member_hierarchy.cc
@@ -54,7 +54,10 @@ MAKE_REFLECT_STRUCT(Out_CqueryMemberHierarchy::Entry,
                     location,
                     numChildren,
                     children);
-MAKE_REFLECT_STRUCT(Out_CqueryMemberHierarchy, jsonrpc, id, result);
+MAKE_REFLECT_STRUCT_OPTIONALS_MANDATORY(Out_CqueryMemberHierarchy,
+                                        jsonrpc,
+                                        id,
+                                        result);
 
 bool Expand(MessageHandler* m,
             Out_CqueryMemberHierarchy::Entry* entry,

--- a/src/messages/text_document_hover.cc
+++ b/src/messages/text_document_hover.cc
@@ -63,20 +63,10 @@ struct Out_TextDocumentHover : public lsOutMessage<Out_TextDocumentHover> {
   optional<Result> result;
 };
 MAKE_REFLECT_STRUCT(Out_TextDocumentHover::Result, contents, range);
-void Reflect(Writer& visitor, Out_TextDocumentHover& value) {
-  REFLECT_MEMBER_START();
-  REFLECT_MEMBER(jsonrpc);
-  REFLECT_MEMBER(id);
-  if (value.result)
-    REFLECT_MEMBER(result);
-  else {
-    // Empty optional<> is elided by the default serializer, we need to write
-    // |null| to be compliant with the LSP.
-    visitor.Key("result");
-    visitor.Null();
-  }
-  REFLECT_MEMBER_END();
-}
+MAKE_REFLECT_STRUCT_OPTIONALS_MANDATORY(Out_TextDocumentHover,
+                                        jsonrpc,
+                                        id,
+                                        result);
 
 struct Handler_TextDocumentHover : BaseMessageHandler<In_TextDocumentHover> {
   MethodType GetMethodType() const override { return kMethodType; }

--- a/src/messages/workspace_execute_command.cc
+++ b/src/messages/workspace_execute_command.cc
@@ -20,14 +20,6 @@ struct Out_WorkspaceExecuteCommand
 };
 MAKE_REFLECT_STRUCT(Out_WorkspaceExecuteCommand, jsonrpc, id, result);
 
-void Reflect(Writer& visitor, Out_WorkspaceExecuteCommand& value) {
-  REFLECT_MEMBER_START();
-  REFLECT_MEMBER(jsonrpc);
-  REFLECT_MEMBER(id);
-  REFLECT_MEMBER(result);
-  REFLECT_MEMBER_END();
-}
-
 struct Handler_WorkspaceExecuteCommand
     : BaseMessageHandler<In_WorkspaceExecuteCommand> {
   MethodType GetMethodType() const override { return kMethodType; }

--- a/src/serializer.h
+++ b/src/serializer.h
@@ -72,10 +72,14 @@ class Writer {
 
 struct IndexFile;
 
+struct optionals_mandatory_tag {};
+
 #define REFLECT_MEMBER_START() ReflectMemberStart(visitor, value)
 #define REFLECT_MEMBER_END() ReflectMemberEnd(visitor, value);
 #define REFLECT_MEMBER_END1(value) ReflectMemberEnd(visitor, value);
 #define REFLECT_MEMBER(name) ReflectMember(visitor, #name, value.name)
+#define REFLECT_MEMBER_OPTIONALS(name) \
+  ReflectMember(visitor, #name, value.name, optionals_mandatory_tag{})
 #define REFLECT_MEMBER2(name, value) ReflectMember(visitor, name, value)
 
 #define MAKE_REFLECT_TYPE_PROXY(type_name) \
@@ -92,6 +96,7 @@ struct IndexFile;
   }
 
 #define _MAPPABLE_REFLECT_MEMBER(name) REFLECT_MEMBER(name);
+#define _MAPPABLE_REFLECT_MEMBER_OPTIONALS(name) REFLECT_MEMBER_OPTIONALS(name);
 
 #define MAKE_REFLECT_EMPTY_STRUCT(type, ...)     \
   template <typename TVisitor>                   \
@@ -106,6 +111,14 @@ struct IndexFile;
     REFLECT_MEMBER_START();                          \
     MACRO_MAP(_MAPPABLE_REFLECT_MEMBER, __VA_ARGS__) \
     REFLECT_MEMBER_END();                            \
+  }
+
+#define MAKE_REFLECT_STRUCT_OPTIONALS_MANDATORY(type, ...)     \
+  template <typename TVisitor>                                 \
+  void Reflect(TVisitor& visitor, type& value) {               \
+    REFLECT_MEMBER_START();                                    \
+    MACRO_MAP(_MAPPABLE_REFLECT_MEMBER_OPTIONALS, __VA_ARGS__) \
+    REFLECT_MEMBER_END();                                      \
   }
 
 // clang-format off
@@ -232,6 +245,15 @@ void ReflectMember(Writer& visitor, const char* name, Maybe<T>& value) {
     visitor.Key(name);
     Reflect(visitor, value);
   }
+}
+
+template <typename T>
+void ReflectMember(Writer& visitor,
+                   const char* name,
+                   T& value,
+                   optionals_mandatory_tag) {
+  visitor.Key(name);
+  Reflect(visitor, value);
 }
 
 // std::vector


### PR DESCRIPTION
The default json serializer omits std::optional fields that aren't
present, but LSP requires exactly one of |result| or |error| to be
present in every json rpc response.  This change fixes the responses of
cquery/{callHierarchy,inheritanceHierarchy,memberHierarchy} so they
always specify a |result| field, even when it's null.

Fixes #652.