### PR TITLE
dropOldRequests config was not added to Config::Completion 

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -247,6 +247,7 @@ MAKE_REFLECT_STRUCT(Config::CodeLens, localVariables);
 MAKE_REFLECT_STRUCT(Config::Completion,
                     enableSnippets,
                     detailedLabel,
+                    dropOldRequests,
                     filterAndSort,
                     includeMaxPathSize,
                     includeSuffixWhitelist,


### PR DESCRIPTION
dropOldRequests config was not added to Config::Completion in 
 599e2f307bd823c734e582d00ed8fd22d5a53f1b