### PR TITLE
Fixed warnings

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -53,6 +53,9 @@
 std::string g_init_options;
 Config* g_config;
 
+#if defined(_WIN32)
+__declspec(dllimport)
+#endif
 extern char** environ;
 
 namespace {

--- a/src/lsp.cc
+++ b/src/lsp.cc
@@ -299,7 +299,7 @@ std::string lsDocumentUri::GetRawPath() const {
   if (raw_uri_.compare(0, 8, "file:///"))
     return raw_uri_;
   std::string ret;
-#ifdef _WIN32
+#if defined(_WIN32)
   size_t i = 8;
 #else
   size_t i = 7;

--- a/src/messages/text_document_definition.cc
+++ b/src/messages/text_document_definition.cc
@@ -143,7 +143,7 @@ struct Handler_TextDocumentDefinition
             continue;
           if (Maybe<Use> use = GetDefinitionSpell(db, db->symbols[i])) {
             std::tuple<int, int, bool, int> score{
-                int(name.size() - short_query.size()), -pos,
+                int(name.size() - short_query.size()), -int(pos),
                 use->file != file_id,
                 std::abs(use->range.start.line - position.line)};
             // Update the score with qualified name if the qualified name
@@ -151,7 +151,7 @@ struct Handler_TextDocumentDefinition
             pos = name.rfind(query);
             if (pos != std::string::npos) {
               std::get<0>(score) = int(name.size() - query.size());
-              std::get<1>(score) = -pos;
+              std::get<1>(score) = -int(pos);
             }
             if (score < best_score) {
               best_score = score;

--- a/src/method.cc
+++ b/src/method.cc
@@ -19,7 +19,8 @@ void Reflect(Reader& visitor, lsRequestId& value) {
     value.value = visitor.GetInt();
   } else if (visitor.IsInt64()) {
     value.type = lsRequestId::kInt;
-    value.value = visitor.GetInt64();
+    // `lsRequestId.value` is an `int`, so we're forced to truncate.
+    value.value = static_cast<int>(visitor.GetInt64());
   } else if (visitor.IsString()) {
     value.type = lsRequestId::kString;
     std::string s = visitor.GetString();

--- a/src/platform_posix.cc
+++ b/src/platform_posix.cc
@@ -114,14 +114,14 @@ optional<AbsolutePath> RealPathNotExpandSymlink(std::string path,
 
 void PlatformInit() {}
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 extern "C" int _NSGetExecutablePath(char* buf, uint32_t* bufsize);
 #endif
 
 // See
 // https://stackoverflow.com/questions/143174/how-do-i-get-the-directory-that-a-program-is-running-from
 AbsolutePath GetExecutablePath() {
-#ifdef __APPLE__
+#if defined(__APPLE__)
   uint32_t size = 0;
   _NSGetExecutablePath(nullptr, &size);
   char* buffer = new char[size];

--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -322,7 +322,7 @@ optional<std::string> RunExecutable(const std::vector<std::string>& command,
       if (!success || bytes_read == 0)
         break;
 
-      for (int i = 0; i < bytes_read; ++i)
+      for (unsigned long i = 0; i < bytes_read; ++i)
         output += buffer[i];
     }
   };

--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -141,7 +141,7 @@ void SetCurrentThreadName(const std::string& thread_name) {
   __try {
     RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR),
                    (ULONG_PTR*)&info);
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
   } __except (EXCEPTION_EXECUTE_HANDLER) {
 #else
   } catch (...) {

--- a/src/project.cc
+++ b/src/project.cc
@@ -513,7 +513,7 @@ std::vector<Project::Entry> LoadCompilationEntriesFromDirectory(
     // Try to load compile_commands.json, but fallback to a project listing.
   } else {
     project->mode = ProjectMode::ExternalCommand;
-#ifdef _WIN32
+#if defined(_WIN32)
 // TODO
 #else
     char tmpdir[] = "/tmp/cquery-compdb-XXXXXX";
@@ -561,7 +561,7 @@ std::vector<Project::Entry> LoadCompilationEntriesFromDirectory(
     }
   }
   if (!g_config->compilationDatabaseCommand.empty()) {
-#ifdef _WIN32
+#if defined(_WIN32)
 // TODO
 #else
     unlink((comp_db_dir + "compile_commands.json").c_str());


### PR DESCRIPTION
This fixed up all the warnings in the build on Windows using the MSVC from Visual Studio 15.7.1 (at least for the warnings displayed by default).