### PR TITLE
Blacklist MSVC `/permissive` and PCH compiler flags

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -174,7 +174,8 @@ std::vector<std::string> kBlacklistMulti = {
 
 // Blacklisted flags which are always removed from the command line.
 std::vector<std::string> kBlacklist = {
-    "-c", "-MP", "-MD", "-MMD", "--fcolor-diagnostics", "-showIncludes"};
+    "-c", "-MP", "-MD", "-MMD", "--fcolor-diagnostics", "-showIncludes",
+    "/permissive", /* These are MSVC PCH flags: */ "/Fp", "/Yc", "/Yu" };
 
 // Arguments which are followed by a potentially relative path. We need to make
 // all relative paths absolute, otherwise libclang will not resolve them.


### PR DESCRIPTION
These are MSVC flags that cause `clang-cl.exe` to crash, and are
unnecessary for cquery.

If the `/permissive` flag is present, it causes this error:

> clang-cl.exe: error: no such file or directory: '/permissive'

If any of the PCH flags are present, the following error occurs:

> error: input is not a PCH file