### PR TITLE
Skip highlighting symbols not actually in file

### DIFF
--- a/src/message_handler.cc
+++ b/src/message_handler.cc
@@ -163,6 +163,9 @@ void EmitSemanticHighlighting(QueryDatabase* db,
             detailed_name.substr(0, detailed_name.find('<'));
         int16_t start_line = sym.range.start.line;
         int16_t start_col = sym.range.start.column;
+        // The function is not there if this isn't at least zero.
+        if (start_line < 0)
+          continue;
         if (start_line >= 0 && start_line < working_file->index_lines.size()) {
           std::string_view line = working_file->index_lines[start_line];
           sym.range.end.line = start_line;


### PR DESCRIPTION
This resolves #675, where cquery would emit multiple `Bad index_line`
errors because it was trying to use `-1` as an index. The cause was
symbols found in a translation unit that weren't visibly present in
the file (e.g. expanded GoogleTest templated macros), and so had a
`start_line` of `-1`. The fix is to simply not publish a semantic
highlight for a symbol that cannot be highlighted.