### PR TITLE
Fix enableSnippets setting in initialize message

### DIFF
--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -547,7 +547,8 @@ struct Handler_Initialize : BaseMessageHandler<In_InitializeRequest> {
       if (!request->params.capabilities.textDocument ||
           !request->params.capabilities.textDocument->completion ||
           !request->params.capabilities.textDocument->completion->completionItem ||
-          !request->params.capabilities.textDocument->completion->completionItem->snippetSupport) {
+          !request->params.capabilities.textDocument->completion->completionItem->snippetSupport ||
+          !request->params.capabilities.textDocument->completion->completionItem->snippetSupport.value()) {
         g_config->completion.enableSnippets = false;
       }
 


### PR DESCRIPTION
`snippetSupport` is actually a std::optional, so if it exists and is false, `enableSnippets` remains true.  Fixes my comment in #657.