### PR TITLE
Add config option for disabling formatting

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -156,6 +156,12 @@ struct Config {
   };
   Completion completion;
 
+  struct Formatting {
+    // Whether formatting should be enabled.
+    bool enabled = true;
+  };
+  Formatting formatting;
+
   struct Diagnostics {
     // Like index.{whitelist,blacklist}, don't publish diagnostics to
     // blacklisted files.
@@ -250,6 +256,8 @@ MAKE_REFLECT_STRUCT(Config::Completion,
                     includeSuffixWhitelist,
                     includeBlacklist,
                     includeWhitelist);
+MAKE_REFLECT_STRUCT(Config::Formatting,
+                    enabled)
 MAKE_REFLECT_STRUCT(Config::Diagnostics,
                     blacklist,
                     whitelist,
@@ -284,6 +292,7 @@ MAKE_REFLECT_STRUCT(Config,
 
                     codeLens,
                     completion,
+                    formatting,
                     diagnostics,
                     highlight,
                     index,

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -563,11 +563,25 @@ struct Handler_Initialize : BaseMessageHandler<In_InitializeRequest> {
 
       // Send initialization before starting indexers, so we don't send a
       // status update too early.
-      // TODO: query request->params.capabilities.textDocument and support
-      // only things the client supports.
 
       Out_InitializeResponse out;
       out.id = request->id;
+
+      // Check if formatting should be enabled.
+      out.result.capabilities.documentFormattingProvider = false;
+      out.result.capabilities.documentRangeFormattingProvider = false;
+      out.result.capabilities.documentOnTypeFormattingProvider.reset();
+      if (g_config->formatting.enabled) {
+        if (request->params.capabilities.textDocument->formatting) {
+          out.result.capabilities.documentFormattingProvider = true;
+        }
+        if (request->params.capabilities.textDocument->rangeFormatting) {
+          out.result.capabilities.documentRangeFormattingProvider = true;
+        }
+      }
+
+      // TODO: query request->params.capabilities.textDocument and support
+      // only things the client supports.
 
       // out.result.capabilities.textDocumentSync =
       // lsTextDocumentSyncOptions();


### PR DESCRIPTION
Add a formatting.enabled (default true) config option to allow the
client to disable formatting. Additionally, only enable the formatting
provider if the client lists it in its capabilities.