### PR TITLE
fix using compilationDatabaseCommand

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -513,7 +513,7 @@ std::vector<Project::Entry> LoadCompilationEntriesFromDirectory(
     return LoadFromDirectoryListing(project);
 
   // If |compilationDatabaseCommand| is specified, execute it to get the compdb.
-  std::string comp_db_dir;
+  std::string comp_db_dir(opt_compilation_db_dir);
   if (g_config->compilationDatabaseCommand.empty()) {
     project->mode = ProjectMode::CompileCommandsJson;
     // Try to load compile_commands.json, but fallback to a project listing.
@@ -542,8 +542,6 @@ std::vector<Project::Entry> LoadCompilationEntriesFromDirectory(
   CXCompilationDatabase_Error cx_db_load_error =
       CXCompilationDatabase_CanNotLoadDatabase;
   CXCompilationDatabase cx_db = nullptr;
-
-  comp_db_dir = opt_compilation_db_dir;
 
   if (!IsAbsolutePath(comp_db_dir)) {
     comp_db_dir =


### PR DESCRIPTION
fix directory that contains generated file.  The dir shouldn't be set
to passed in arg after a temp directory is generated and created.