### PR TITLE
Default back to Ubuntu 14.04 when downloading Clang

### DIFF
--- a/cmake/DownloadAndExtractClang.cmake
+++ b/cmake/DownloadAndExtractClang.cmake
@@ -13,7 +13,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
 
   # Default to Ubuntu 16.04
   set(CLANG_ARCHIVE_NAME 
-      clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-16.04)
+      clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04)
 
   find_program(LSB_RELEASE lsb_release)
   if(LSB_RELEASE)
@@ -23,9 +23,9 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    if(${UBUNTU_VERSION} MATCHES 14.04)
+    if(${UBUNTU_VERSION} MATCHES 16.04)
       set(CLANG_ARCHIVE_NAME 
-          clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04)
+          clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-16.04)
     endif()
   endif()
 


### PR DESCRIPTION
See #750 

Only use Ubuntu 16.04 on Ubuntu 16.04.

We could keep the 16.04 default but that means adding exceptions for every distro that doesn't work with the 16.04 archive which means extra maintenance burden. Since we didn't get any reports of issues with the 14.04 archive I think we're better off without that extra maintenance and defaulting to 14.04