### PR TITLE
Set _WIN32_WINNT for SHGetKnownFolderPath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   target_link_libraries(cquery PRIVATE ${Backtrace_LIBRARIES} kvm thr)
 
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL Windows)
+  target_compile_definitions(cquery PRIVATE _WIN32_WINNT=0x0600) # Windows Vista
   # sparsepp/spp_memory.h uses LibPsapi
   target_link_libraries(cquery PRIVATE Psapi)
 endif()


### PR DESCRIPTION
As [documented in MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath) this function requires Windows Vista or newer. While Visual Studio can't compile for XP anymore anyway,  Mingw-w64 still cares and won't define the function without the correctly set `_WIN32_WINNT` version.

~~Sorry about the removed trailing whitespaces, if you want I can clean that up so that my patch is only the one added line.~~
edit: `add_compile_definitions` -> `target_compile_definitions`