### PR TITLE
Hash argument lists in IndexFiles

### DIFF
--- a/src/clang_indexer.cc
+++ b/src/clang_indexer.cc
@@ -732,7 +732,7 @@ void Uniquify(std::vector<IndexId::LexicalRef>& refs) {
 }  // namespace
 
 // static
-const int IndexFile::kMajorVersion = 15;
+const int IndexFile::kMajorVersion = 16;
 // static
 const int IndexFile::kMinorVersion = 0;
 
@@ -2272,7 +2272,7 @@ optional<std::vector<std::unique_ptr<IndexFile>>> Parse(
       inc_to_line[inc.resolved_path] = inc.line;
 
   auto result = param.file_consumer->TakeLocalState();
-  auto args_hash = hash_arguments(args);
+  auto args_hash = HashArguments(args);
   for (std::unique_ptr<IndexFile>& entry : result) {
     entry->import_file = *file;
     entry->args_hash = args_hash;

--- a/src/clang_indexer.cc
+++ b/src/clang_indexer.cc
@@ -2272,9 +2272,10 @@ optional<std::vector<std::unique_ptr<IndexFile>>> Parse(
       inc_to_line[inc.resolved_path] = inc.line;
 
   auto result = param.file_consumer->TakeLocalState();
+  auto args_hash = hash_arguments(args);
   for (std::unique_ptr<IndexFile>& entry : result) {
     entry->import_file = *file;
-    entry->args = args;
+    entry->args_hash = args_hash;
     for (IndexFunc& func : entry->funcs) {
       // e.g. declaration + out-of-line definition
       Uniquify(func.derived);

--- a/src/import_pipeline.cc
+++ b/src/import_pipeline.cc
@@ -165,7 +165,7 @@ ChangeResult ComputeChangeStatus(
   }
 
   if (opt_previous_index) {
-    if (hash_arguments(args) != opt_previous_index->args_hash) {
+    if (HashArguments(args) != opt_previous_index->args_hash) {
       LOG_S(INFO) << "Arguments have changed for " << path << unwrap_opt(from);
       return ChangeResult::kYes;
     }
@@ -700,7 +700,7 @@ TEST_SUITE("ImportPipeline") {
       if (!old_args.empty()) {
         opt_previous_index = std::make_unique<IndexFile>(
             AbsolutePath("---.cc", false /*validate*/));
-        opt_previous_index->args_hash = hash_arguments(old_args);
+        opt_previous_index->args_hash = HashArguments(old_args);
       }
       optional<AbsolutePath> from;
       if (is_dependency)

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -461,7 +461,7 @@ struct IndexFile {
   static const int kMinorVersion;
 
   AbsolutePath path;
-  std::vector<std::string> args;
+  size_t args_hash;
   int64_t last_modification_time = 0;
   LanguageId language = LanguageId::Unknown;
 

--- a/src/messages/cquery_file_info.cc
+++ b/src/messages/cquery_file_info.cc
@@ -37,7 +37,7 @@ struct Handler_CqueryFileInfo : BaseMessageHandler<In_CqueryFileInfo> {
     out.id = request->id;
     // Expose some fields of |QueryFile::Def|.
     out.result.path = file->def->path;
-    out.result.args = file->def->args;
+    out.result.args_hash = file->def->args_hash;
     out.result.language = file->def->language;
     out.result.includes = file->def->includes;
     out.result.inactive_regions = file->def->inactive_regions;

--- a/src/query.cc
+++ b/src/query.cc
@@ -220,7 +220,6 @@ QueryFile::DefUpdate BuildFileDefUpdate(const IdMap& id_map,
   QueryFile::Def def;
   def.file = id_map.primary_file;
   def.path = indexed.path;
-  def.args = indexed.args;
   def.includes = indexed.includes;
   def.inactive_regions = indexed.skipped_by_preprocessor;
   def.dependencies = indexed.dependencies;

--- a/src/query.h
+++ b/src/query.h
@@ -99,7 +99,7 @@ struct QueryFile {
   struct Def {
     QueryId::File file;
     AbsolutePath path;
-    std::vector<std::string> args;
+    size_t args_hash;
     // Language identifier
     std::string language;
     // Includes in the file.
@@ -130,7 +130,7 @@ struct QueryFile {
 MAKE_REFLECT_STRUCT(QueryFile::Def,
                     file,
                     path,
-                    args,
+                    args_hash,
                     language,
                     outline,
                     all_symbols,

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -284,7 +284,7 @@ void Reflect(TVisitor& visitor, IndexFile& value) {
     REFLECT_MEMBER(last_modification_time);
     REFLECT_MEMBER(language);
     REFLECT_MEMBER(import_file);
-    REFLECT_MEMBER(args);
+    REFLECT_MEMBER(args_hash);
   }
   REFLECT_MEMBER(includes);
   if (!gTestOutputMode)

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -476,6 +476,19 @@ bool IsDirectory(const std::string& path) {
   return path_stat.st_mode & S_IFDIR;
 }
 
+size_t HashArguments(const std::vector<std::string>& args) {
+  auto is_file = [](const std::string& arg) {
+    return EndsWithAny(arg, {".h", ".c", ".cc", ".cpp", ".hpp", ".m", ".mm"});
+  };
+  size_t hash = 0;
+  for (auto it = args.begin(); it != args.end(); it++) {
+    if (!is_file(*it)) {
+      hash_combine(hash, *it);
+    }
+  }
+  return hash;
+}
+
 TEST_SUITE("AbsolutePath") {
   TEST_CASE("IsWindowsAbsolutePath works correctly") {
     REQUIRE(IsWindowsAbsolutePath("C:/Users/projects/"));

--- a/src/utils.h
+++ b/src/utils.h
@@ -144,4 +144,16 @@ bool IsAbsolutePath(const std::string& path);
 bool IsUnixAbsolutePath(const std::string& path);
 bool IsWindowsAbsolutePath(const std::string& path);
 
+inline size_t hash_arguments(const std::vector<std::string>& args) {
+  auto is_file = [](const std::string& arg) {
+    return EndsWithAny(arg, {".h", ".c", ".cc", ".cpp", ".hpp", ".m", ".mm"});
+  };
+  size_t hash = 0;
+  for (auto it = args.begin(); it != args.end(); it++) {
+    if (!is_file(*it)) {
+      hash_combine(hash, *it);
+    }
+  }
+  return hash;
+}
 bool IsDirectory(const std::string& path);

--- a/src/utils.h
+++ b/src/utils.h
@@ -144,16 +144,6 @@ bool IsAbsolutePath(const std::string& path);
 bool IsUnixAbsolutePath(const std::string& path);
 bool IsWindowsAbsolutePath(const std::string& path);
 
-inline size_t hash_arguments(const std::vector<std::string>& args) {
-  auto is_file = [](const std::string& arg) {
-    return EndsWithAny(arg, {".h", ".c", ".cc", ".cpp", ".hpp", ".m", ".mm"});
-  };
-  size_t hash = 0;
-  for (auto it = args.begin(); it != args.end(); it++) {
-    if (!is_file(*it)) {
-      hash_combine(hash, *it);
-    }
-  }
-  return hash;
-}
 bool IsDirectory(const std::string& path);
+
+size_t HashArguments(const std::vector<std::string>& args);


### PR DESCRIPTION
On large projects where thousands of files each have thousands of arguments,
the args array of IndexFiles ends up causing cquery to run out of memory.

Currently the array is only used to check whether it can reload indices from cache,
so let it just store a hash and compare that instead of the full array.