### PR TITLE
Implement compilationDatabaseCommand on Windows

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -37,6 +37,9 @@ void MakeDirectoryRecursive(const AbsolutePath& path);
 // does not attempt to recursively create directories.
 bool TryMakeDirectory(const AbsolutePath& path);
 
+// tmpl: template string for mkdtemp(3), ignored on windows.
+optional<AbsolutePath> TryMakeTempDirectory(char *tmpl);
+
 void SetCurrentThreadName(const std::string& thread_name);
 
 optional<int64_t> GetLastModificationTime(const AbsolutePath& absolute_path);

--- a/src/platform_posix.cc
+++ b/src/platform_posix.cc
@@ -175,6 +175,13 @@ bool TryMakeDirectory(const AbsolutePath& absolute_path) {
   return true;
 }
 
+optional<AbsolutePath> TryMakeTempDirectory(char *tmpl) {
+    if(!mkdtemp(tmpl)) {
+        return {};
+    }
+    return AbsolutePath(tmpl);
+}
+
 void SetCurrentThreadName(const std::string& thread_name) {
   loguru::set_thread_name(thread_name.c_str());
 #if defined(__APPLE__)


### PR DESCRIPTION
The `_WIN32`-part only contained a `//TODO` marker, so I provided an implementation.