### PR TITLE
Clear code completion cache after indexing. Should fix #754

### DIFF
--- a/src/code_complete_cache.cc
+++ b/src/code_complete_cache.cc
@@ -10,3 +10,10 @@ bool CodeCompleteCache::IsCacheValid(lsTextDocumentPositionParams position) {
   return cached_path_ == position.textDocument.uri.GetAbsolutePath() &&
          cached_completion_position_ == position.position;
 }
+
+void CodeCompleteCache::Clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  cached_path_.reset();
+  cached_completion_position_.reset();
+  cached_results_.clear();
+}

--- a/src/code_complete_cache.h
+++ b/src/code_complete_cache.h
@@ -19,4 +19,5 @@ struct CodeCompleteCache {
 
   void WithLock(std::function<void()> action);
   bool IsCacheValid(lsTextDocumentPositionParams position);
+  void Clear();
 };

--- a/src/import_pipeline.h
+++ b/src/import_pipeline.h
@@ -10,6 +10,7 @@ struct QueryDatabase;
 struct SemanticHighlightSymbolCache;
 struct TimestampManager;
 struct WorkingFiles;
+struct CodeCompleteCache;
 
 // FIXME: rename
 struct ImportPipelineStatus {
@@ -25,7 +26,9 @@ void Indexer_Main(DiagnosticsEngine* diag_engine,
                   ImportManager* import_manager,
                   ImportPipelineStatus* status,
                   Project* project,
-                  WorkingFiles* working_files);
+                  WorkingFiles* working_files,
+                  CodeCompleteCache* global_code_complete_cache,
+                  CodeCompleteCache* non_global_code_complete_cache);
 
 bool QueryDb_ImportMain(QueryDatabase* db,
                         ImportManager* import_manager,

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -636,7 +636,8 @@ struct Handler_Initialize : BaseMessageHandler<In_InitializeRequest> {
         WorkThread::StartThread("indexer" + std::to_string(i), [=]() {
           Indexer_Main(diag_engine, file_consumer_shared, timestamp_manager,
                        import_manager, import_pipeline_status, project,
-                       working_files);
+                       working_files, global_code_complete_cache,
+                       non_global_code_complete_cache);
         });
       }
 


### PR DESCRIPTION
Should fix #754. Cached completions are still being used after indexing, so clearing them after indexing should cause it to do a full completion on the next call.