### PR TITLE
Move to clang 7.0.0 for Darwin

### DIFF
--- a/cmake/DownloadAndExtractClang.cmake
+++ b/cmake/DownloadAndExtractClang.cmake
@@ -31,8 +31,6 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
 
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
 
-  # No Darwin binaries were released for LLVM 6.0.1
-  set(CLANG_VERSION 6.0.0)
   set(CLANG_ARCHIVE_NAME clang+llvm-${CLANG_VERSION}-x86_64-apple-darwin)
 
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL Windows)


### PR DESCRIPTION
All system clang has been migrated to clang 7.0.0, but clang 6.0.0 for Darwin remains in `cmake/DownloadAndExtractClang.cmake`. and there is no hash file for clang 6.0.0/6.0.1, it will get an error when `cmake ..`

```
-- Using downloaded Clang
CMake Error at cmake/DownloadAndExtractClang.cmake:72 (message):
  No SHA256 hash available for the current platform (Darwin) + clang version
  (6.0.0) combination.  Please file an issue to get it added.
Call Stack (most recent call first):
  CMakeLists.txt:94 (download_and_extract_clang)
```