### PR TITLE
The entry "compilerPath" is now considered when parsing "c_cpp_properties.json"

### DIFF
--- a/src/clang_system_include_extractor.h
+++ b/src/clang_system_include_extractor.h
@@ -13,3 +13,9 @@ std::vector<std::string> FindSystemIncludeDirectories(
     const std::string& language,
     const std::string& working_directory,
     const std::vector<std::string>& extra_flags);
+
+std::vector<std::string> FindSystemDefines(
+    const std::vector<std::string>& compiler_drivers,
+    const std::string& language,
+    const std::string& working_directory,
+    const std::vector<std::string>& extra_flags);


### PR DESCRIPTION
The entry `compilerPath` is now considered when parsing `c_cpp_properties.json`. If absent, the clang compiler is assumed. Fixes #812.

Detect implicit C/C++ preprocessor defines. Fixes #814.