### PR TITLE
[BUGFIX] Don't use DiagnosticsEngine without initialization.

### DIFF
--- a/src/command_line.cc
+++ b/src/command_line.cc
@@ -209,6 +209,7 @@ void RunQueryDbThread(const std::string& bin_name) {
   WorkingFiles working_files;
   FileConsumerSharedState file_consumer_shared;
   DiagnosticsEngine diag_engine;
+  diag_engine.Init();
 
   ClangCompleteManager clang_complete(
       &project, &working_files,


### PR DESCRIPTION
This PR fixes a bug in src/command_line.cc -> RunQueryDbThread(). The DiagnosticsEngine was used without being properly initialized.