### PR TITLE
Issue 841 fix - some arguments to the compiler might be processed as a path

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -423,7 +423,7 @@ Project::Entry GetCompilationEntryFromCompileCommandEntry(
       // path needs to be absolute, otherwise clang_codeCompleteAt is extremely
       // slow. See
       // https://github.com/cquery-project/cquery/commit/af63df09d57d765ce12d40007bf56302a0446678.
-      if (EndsWith(arg, base_name))
+      if (EndsWith(arg, base_name) && !StartsWith(arg, "-"))
         arg = cleanup_maybe_relative_path(arg).path;
       // TODO Exclude .a .o to make link command in compile_commands.json work.
       // Also, clang_parseTranslationUnit2FullArgv does not seem to accept


### PR DESCRIPTION
Fixes the [Issue 841](https://github.com/cquery-project/cquery/issues/841)
Detecting a file path within the arguments list by comparing a postfix with the file name does not work correctly.
Checking that the file-name argument should not start with the dash should fix it for now.