### PR TITLE
Fix path normalizations with correct case for all directories.

### DIFF
--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -93,7 +93,13 @@ optional<AbsolutePath> NormalizePath(const std::string& path0,
   // and this function is called with `c:\fooBar` this will return `c:\FooBar`.
   // (drive casing is lowercase).
   if (ensure_exists) {
-    len = GetLongPathName(path.c_str(), buffer, MAX_PATH);
+    // Ensure 'GetLongPathName' actually transforms every path segment to the correct
+    // case by first making all directories in 8.3 format.
+    len = GetShortPathName(path.c_str(), buffer, MAX_PATH);
+    if (!len)
+      return nullopt;
+    std::string shortPath(buffer, len);
+    len = GetLongPathName(shortPath.c_str(), buffer, MAX_PATH);
     if (!len)
       return nullopt;
     path = std::string(buffer, len);


### PR DESCRIPTION
When using cquery inside VS Code I often got files "out of workspace" even though they are in it. This has unwanted effects like creating file save conflicts and breakpoints are incorrectly associated with their "out of workspace" counter part.
Now, `GetLongPathName` is used to ensure all directory names are transformed into their correct case (as stated by the comments). However, it seems like path elements already in the long format are kept as-is by the Windows API. Or at least there is something not working as intended with the call to `GetLongPathName`.
So, as it seems, by first transforming the path into its "short" 8.3 representation, I am able to force a subsequent call to `GetLongPathName` to transform all path elements into the correct case.
This in turn means the internal path matching in VS Code still identifies paths within the workspace to be correctly relative to the workspace root.