### PR TITLE
Fix crash on VSCode Gitlens paths (e.g. in diffview)

### DIFF
--- a/src/lsp.cc
+++ b/src/lsp.cc
@@ -332,7 +332,11 @@ std::string lsDocumentUri::GetRawPath() const {
 }
 
 AbsolutePath lsDocumentUri::GetAbsolutePath() const {
-  return *NormalizePath(GetRawPath(), false /*ensure_exists*/);
+  optional<AbsolutePath> normalized = NormalizePath(GetRawPath(), false /*ensure_exists*/);
+  if (!normalized) {
+    return AbsolutePath();
+  }
+  return *normalized;
 }
 
 void Reflect(Writer& visitor, lsDocumentUri& value) {


### PR DESCRIPTION
I am using cquery in conjunction with the cquery VS Code plugin. I also use Gitlens. I have found that cquery crashes instantly upon entering a diff view.
As it turns out, being unable to normalize the path in these cases exposed a problem with not dealing with the `optional<>` not being set which specifically led to my crashes.