### PR TITLE
cquery would not compile without adding #include<string>

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <unordered_map>
-
+#include <string>
 std::unordered_map<std::string, std::string> ParseOptions(int argc,
                                                           char** argv);
 


### PR DESCRIPTION
I had to add #include<string> for cquery to compile. 